### PR TITLE
Update daemon.py

### DIFF
--- a/src/lldp_syncd/daemon.py
+++ b/src/lldp_syncd/daemon.py
@@ -118,7 +118,10 @@ class LldpSyncDaemon(SonicSyncDaemon):
         """
         try:
             # [{'enabled': ..., 'type': 'capability1'}, {'enabled': ..., 'type': 'capability2'}]
-            capability_list = if_attributes['chassis'].values()[0]['capability']
+            if 'capability' in if_attributes['chassis']:
+                capability_list = if_attributes['chassis']['capability']
+            else:
+                capability_list = if_attributes['chassis'].values()[0]['capability']
             # {'enabled': ..., 'type': 'capability'}
             if isinstance(capability_list, dict):
                 capability_list = [capability_list]


### PR DESCRIPTION
Current get_sys_capability_list don't consider the system name of remote device is null case. 
If devices don't configure host name, it will send out LLDPPDU whose System Name TLV is null string.
When sonic device learned the remote device, the chassis object of lldp_json does not include system name string.
The capability_list does not get successfully by applying current statement, capability_list = if_attributes['chassis'].values()[0]['capability'].
We can execute lldpclt command to see the difference.    
root@sonic:~# docker exec -it lldp bash
root@sonic:/# /usr/sbin/lldpctl -f json
[Remote device without system name]
        "chassis": {
          ...
          "capability": [
            {
              "type": "Bridge",
              "enabled": true
            },
            {
              "type": "Router",
              "enabled": true
            }
          ]
        }
[Remote device with system name]
        "chassis": {
          "system_name": {
            ......
            "capability": [
              {
                "type": "Bridge",
                "enabled": true
              },
              {
                "type": "Router",
                "enabled": true
              }
            ]
          }
        }